### PR TITLE
feat(stock)[gfdc]: product cost & supplier + margin

### DIFF
--- a/Areas/Admin/Views/Products/Create.cshtml
+++ b/Areas/Admin/Views/Products/Create.cshtml
@@ -18,6 +18,8 @@
     </div>
 
     <form method="post" asp-area="Admin" asp-controller="Products" asp-action="Create" class="row g-3">
+        @Html.AntiForgeryToken()
+
         <div class="col-md-8">
             <label class="form-label">Title</label>
             <input name="Title" class="form-control" placeholder="e.g., C# Bear" />
@@ -34,8 +36,24 @@
         </div>
 
         <div class="col-md-4">
+            <label class="form-label">Cost</label>
+            <input name="CostPrice" type="number" step="0.01" class="form-control" placeholder="0.00" />
+        </div>
+
+        <div class="col-md-4">
             <label class="form-label">Stock</label>
-            <input name="Stock" type="number" class="form-control" placeholder="0" />
+            <!-- note to self: property is StockQty (not Stock) -->
+            <input name="StockQty" type="number" class="form-control" placeholder="0" />
+        </div>
+
+        <div class="col-md-6">
+            <label class="form-label">Supplier</label>
+            <input name="Supplier" class="form-control" placeholder="optional supplier name" />
+        </div>
+
+        <div class="col-md-6">
+            <label class="form-label">Image URL</label>
+            <input name="ImageUrl" class="form-control" placeholder="/images/products/..." />
         </div>
 
         <div class="col-12 d-flex gap-2">
@@ -44,4 +62,5 @@
         </div>
     </form>
 </section>
+
 

--- a/Areas/Admin/Views/Products/Edit.cshtml
+++ b/Areas/Admin/Views/Products/Edit.cshtml
@@ -47,9 +47,30 @@
         </div>
 
         <div class="col-md-4">
+            <label asp-for="CostPrice" class="form-label"></label> @* internal cost for margin *@
+            <input asp-for="CostPrice" class="form-control" />
+            <span asp-validation-for="CostPrice" class="text-danger"></span>
+        </div>
+
+        <div class="col-md-4">
             <label asp-for="StockQty" class="form-label"></label>
             <input asp-for="StockQty" class="form-control" />
             <span asp-validation-for="StockQty" class="text-danger"></span>
+        </div>
+
+        <div class="col-md-6">
+            <label asp-for="Supplier" class="form-label"></label> @* optional supplier note *@
+            <input asp-for="Supplier" class="form-control" />
+            <span asp-validation-for="Supplier" class="text-danger"></span>
+        </div>
+
+        <div class="col-12 d-flex align-items-center gap-3">
+            <div class="text-muted">
+                @* quick read-only margin helpers for a sanity check *@
+                <strong>Margin:</strong> @Model.Margin.ToString("C")
+                &nbsp;|&nbsp;
+                <strong>Margin%:</strong> @Model.MarginPercent.ToString("0.0")%
+            </div>
         </div>
 
         <div class="col-12 d-flex gap-2">
@@ -63,4 +84,3 @@
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
 }
-

--- a/Areas/Admin/Views/Products/Index.cshtml
+++ b/Areas/Admin/Views/Products/Index.cshtml
@@ -52,8 +52,12 @@
                         <th style="width:72px">Image</th>
                         <th>Title</th>
                         <th>Category</th>
-                        <th>Price</th>
-                        <th>Stock</th>
+                        <th class="text-end">Price</th>
+                        <th class="text-end">Cost</th>        @* new: CostPrice *@
+                        <th class="text-end">Margin</th>      @* new: Price - CostPrice *@
+                        <th class="text-end">Margin%</th>     @* new: (Price-Cost)/Price *@
+                        <th class="text-end">Stock</th>
+                        <th>Supplier</th>                     @* new: Supplier note *@
                         <th class="text-end">Actions</th>
                     </tr>
                 </thead>
@@ -79,10 +83,22 @@
 
                             <td><span class="badge bg-secondary">@p.Category</span></td>
 
-                            <td>@p.Price.ToString("C")</td>
+                            <td class="text-end">@p.Price.ToString("C")</td>
 
-                            @* If your property is StockQty instead of Stock, change to @p.StockQty *@
-                            <td>@p.StockQty</td>
+                            @* new: internal cost used for margin *@
+                            <td class="text-end">@p.CostPrice.ToString("C")</td>
+
+                            @* new: absolute margin *@
+                            <td class="text-end">@p.Margin.ToString("C")</td>
+
+                            @* new: percentage margin (one decimal) *@
+                            <td class="text-end">@p.MarginPercent.ToString("0.0")%</td>
+
+                            @* If the property is StockQty (it is), keep as-is *@
+                            <td class="text-end">@p.StockQty</td>
+
+                            @* new: show supplier or dash *@
+                            <td>@(string.IsNullOrWhiteSpace(p.Supplier) ? "-" : p.Supplier)</td>
 
                             <td class="text-end">
                                 <div class="btn-group">
@@ -91,6 +107,7 @@
 
                                     <form asp-area="Admin" asp-controller="Products" asp-action="Delete" asp-route-id="@p.Id"
                                           method="post" onsubmit="return confirm('Delete this product?');">
+                                        @Html.AntiForgeryToken()
                                         <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
                                     </form>
                                 </div>
@@ -102,4 +119,3 @@
         </div>
     }
 </section>
-

--- a/Migrations/20251007124205_AddCostPriceAndSupplierToProduct.Designer.cs
+++ b/Migrations/20251007124205_AddCostPriceAndSupplierToProduct.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EasyGames.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EasyGames.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251007124205_AddCostPriceAndSupplierToProduct")]
+    partial class AddCostPriceAndSupplierToProduct
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/Migrations/20251007124205_AddCostPriceAndSupplierToProduct.cs
+++ b/Migrations/20251007124205_AddCostPriceAndSupplierToProduct.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EasyGames.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCostPriceAndSupplierToProduct : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "CostPrice",
+                table: "Products",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Supplier",
+                table: "Products",
+                type: "TEXT",
+                maxLength: 120,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CostPrice",
+                table: "Products");
+
+            migrationBuilder.DropColumn(
+                name: "Supplier",
+                table: "Products");
+        }
+    }
+}

--- a/Models/Product.cs
+++ b/Models/Product.cs
@@ -4,6 +4,7 @@
 // why: minimal fields to render store cards + admin stock; simple validation to stop bad data early
 // note: enum keeps allowed types fixed (no typos); decimal for money to avoid float rounding
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace EasyGames.Models
 {
@@ -12,11 +13,33 @@ namespace EasyGames.Models
     public class Product
     {
         public int Id { get; set; }
-        [Required, MaxLength(120)] public string Title { get; set; } = "";
+
+        [Required, MaxLength(120)]
+        public string Title { get; set; } = "";
+
         public Category Category { get; set; }
-        [Range(0, 9999)] public decimal Price { get; set; }
-        [Range(0, int.MaxValue)] public int StockQty { get; set; }
+
+        [Range(0, 9999)]
+        public decimal Price { get; set; }
+
+        [Range(0, int.MaxValue)]
+        public int StockQty { get; set; }
+
         public string? ImageUrl { get; set; }
+
+        // --- owner fields (added for A3) ---
+        // cost to compute profit; default 0 for existing rows
+        [Range(0, 999999)]
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal CostPrice { get; set; } = 0m;
+
+        // optional supplier note for admin reference
+        [MaxLength(120)]
+        public string? Supplier { get; set; }
+
+        // convenience (not stored) for admin lists
+        [NotMapped] public decimal Margin => Price - CostPrice;                    // quick absolute margin
+        [NotMapped] public decimal MarginPercent => Price <= 0 ? 0 : (Price - CostPrice) / Price * 100m; // quick %
     }
 }
 


### PR DESCRIPTION
- Adds Product.CostPrice (decimal 18,2) and Supplier (string?)
- Non-mapped helpers: Margin and MarginPercent
- Updates Admin Products: Index (Price, Cost, Margin, Margin%), Create/Edit (CostPrice, Supplier)
- Seeder backfills cost=0, normalises supplier, fixes image fields
- Includes EF migration: AddCostPriceAndSupplierToProduct
